### PR TITLE
[tests] Fix failing tests

### DIFF
--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Venu Vardhan Reddy Tekula <venu@bitergia.com>
 #
 
 import os
@@ -84,10 +85,10 @@ CHANGELOG_DIR_NOT_FOUND_ERROR = (
     r"Error: changelog entries directory '.+' does not exist"
 )
 INVALID_NAME_ERROR = (
-    "Error: Invalid value for \"NAME\": cannot be empty"
+    "Error: Invalid value for \"|\'NAME\"|\': cannot be empty"
 )
 INVALID_VERSION_ERROR = (
-    "Error: Invalid value for \"VERSION\": cannot be empty"
+    "Error: Invalid value for \"|\'VERSION\"|\': cannot be empty"
 )
 
 
@@ -445,19 +446,19 @@ class TestNotes(unittest.TestCase):
         self.assertEqual(result.exit_code, 2)
 
         lines = result.stderr.split('\n')
-        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+        self.assertRegex(lines[-2], INVALID_NAME_ERROR)
 
         # Only whitespaces are not allowed
         result = runner.invoke(notes, [' '])
         self.assertEqual(result.exit_code, 2)
 
         lines = result.stderr.split('\n')
-        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+        self.assertRegex(lines[-2], INVALID_NAME_ERROR)
 
         # Only control characters are not allowed
         result = runner.invoke(notes, ['\n\r\n'])
         self.assertEqual(result.exit_code, 2)
-        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+        self.assertRegex(lines[-2], INVALID_NAME_ERROR)
 
     def test_invalid_version(self):
         """Check whether version argument is validated correctly"""
@@ -469,19 +470,19 @@ class TestNotes(unittest.TestCase):
         self.assertEqual(result.exit_code, 2)
 
         lines = result.stderr.split('\n')
-        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+        self.assertRegex(lines[-2], INVALID_VERSION_ERROR)
 
         # Only whitespaces are not allowed
         result = runner.invoke(notes, ['release-tools', ' '])
         self.assertEqual(result.exit_code, 2)
 
         lines = result.stderr.split('\n')
-        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+        self.assertRegex(lines[-2], INVALID_VERSION_ERROR)
 
         # Only control characters are not allowed
         result = runner.invoke(notes, ['release-tools', '\n\r\n'])
         self.assertEqual(result.exit_code, 2)
-        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+        self.assertRegex(lines[-2], INVALID_VERSION_ERROR)
 
 
 if __name__ == '__main__':

--- a/tests/test_semverup.py
+++ b/tests/test_semverup.py
@@ -126,7 +126,6 @@ class TestSemVerUp(unittest.TestCase):
                                 fd.read(), re.MULTILINE).group(1)
         return version
 
-
     @staticmethod
     def read_version_number_from_pyproject(filepath):
         """Returns the version number stored in a pyproject file"""
@@ -137,7 +136,6 @@ class TestSemVerUp(unittest.TestCase):
         poetry_metadata = metadata["tool"]["poetry"]
 
         return poetry_metadata["version"]
-
 
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_version_is_updated(self, mock_project):


### PR DESCRIPTION
A few tests are failing when you install release-tools as a package. This commit fixes all those failing tests.

This is necessary as we would soon upload automate the release process using github actions and upload the package to PyPI whenever there is a new release.

It also fixes a few flake8 errors.